### PR TITLE
Improve handling of keyboard, cursor and beeper

### DIFF
--- a/emulator/ncurses-vt100/keyboard.cpp
+++ b/emulator/ncurses-vt100/keyboard.cpp
@@ -4,7 +4,7 @@
 #include "8080/simglb.h"
 #include <ncurses.h>
 
-Keyboard::Keyboard() : state(KBD_IDLE), latch(0), tx_buf_empty(true)
+Keyboard::Keyboard() : state(KBD_IDLE), latch(0)
 {
     scan_iter = scan.end();
 }
@@ -14,7 +14,7 @@ uint8_t Keyboard::get_latch()
     return latch;
 }
 
-bool Keyboard::get_tx_buf_empty() { return tx_buf_empty; }
+bool Keyboard::get_tx_buf_empty() { return !tx_buf_count; }
 
 extern WINDOW* msgWin;
 
@@ -22,6 +22,10 @@ extern WINDOW* msgWin;
  * The VT100 triggers keyboard scans by setting bit (1<<6) in the status.
  * It then expects to receive one or more scan codes followed by an 0x7F
  * byte to indicate the end of the scan. Each byte takes 160 clocks to send.
+ *
+ * The real VT100 has a double buffer on it's UART, (like the keyboard) so
+ * the transmit delay may be up to 320 clocks, however, direct xmit is
+ * sufficient for the simulation.
  *
  * Setup and NoScroll are triggered as soon as they are received.
  *
@@ -33,7 +37,7 @@ extern WINDOW* msgWin;
  * time.
  *
  * The double scan and thee key maximum requirements prevent 'ghost'
- * keypresses trigged by the maxtrix being accepted.
+ * keypresses trigged by the matrix being accepted.
  *
  * There is a 9 character buffer for transmitting data to the host; this must
  * have at least 3 bytes free. If it doesn't the keyboard lock is asserted.
@@ -47,14 +51,16 @@ void Keyboard::set_status(uint8_t status)
         //printf("SCAN START\n");fflush(stdout);
       //wprintw(msgWin,"Scan start\n");wrefresh(msgWin);
         state = KBD_SENDING;
-        clocks_until_next = 160;
 
+	// NB: Time for the status to be received + time for the reply.
+        clocks_until_next = 160+160;
     }
 
     if (status & 0x80) {
-	// TODO: FIX too main beeps.
-	beep();
-    }
+	if (!beeping) beep();
+	if (tx_buf_count == 0) beeping = (beeping+1) % 48;
+    } else beeping = 0;
+    if (tx_buf_count == 0) tx_buf_count = 160;
 }
 
 void Keyboard::keypress(uint8_t keycode)
@@ -66,16 +72,46 @@ void Keyboard::keypress(uint8_t keycode)
 bool Keyboard::clock(bool rising)
 {
     if (!rising) { return false; }
+    if (tx_buf_count>0) tx_buf_count--;
     switch (state) {
     case KBD_IDLE:
         break;
     case KBD_SENDING:
         if (clocks_until_next == 0) {
-	  scan = last_sent;
-		// hack around debounce problem
-	  last_sent = keys;
-	  scan.insert(keys.begin(),keys.end());
-            keys.clear();
+	    if (keys.size() == 1 && last_sent.size() == 1 &&
+		sending == KBD_SEND_2 &&
+		scan.count(*(keys.begin())) == 0)  {
+
+	      // Use keyboard rollover
+	      scan = keys;
+	      if (sending == KBD_SEND_1)
+		scan.insert(last_sent.begin(),last_sent.end());
+
+	      sending = KBD_SEND_1;
+	      last_sent = keys;
+	      keys.clear();
+
+	    } else if (last_sent.size() != 0) {
+	      if (sending == KBD_SEND_1) {
+		sending = KBD_SEND_2;
+	      } else {
+		scan.clear();
+		last_sent.clear();
+		sending = KBD_IDLE;
+	      }
+	    } else if( keys.size() != 0) {
+	      // We have sent an empty set, start next.
+	      scan = keys;
+	      last_sent = keys;
+	      sending = KBD_SEND_1;
+	      keys.clear();
+	    } else {
+	      // Nothing sending and nothing to send.
+	      sending = KBD_IDLE;
+	      scan.clear();
+	      keys.clear();
+	    }
+
             scan_iter = scan.begin();
             state = KBD_RESPONDING;
             clocks_until_next = 160;

--- a/emulator/ncurses-vt100/keyboard.h
+++ b/emulator/ncurses-vt100/keyboard.h
@@ -8,6 +8,8 @@ typedef enum {
     KBD_IDLE =0,
     KBD_SENDING =1,
     KBD_RESPONDING =2,
+    KBD_SEND_1 =3,
+    KBD_SEND_2 =4,
 } KbdState;
 
 class Keyboard
@@ -17,10 +19,11 @@ public:
     uint8_t get_latch();
     bool get_tx_buf_empty();
 private:
-    KbdState state;
+    KbdState state, sending;
     uint8_t latch;
     uint8_t last_status;
-    bool tx_buf_empty;
+    uint8_t tx_buf_count;
+    uint8_t beeping;
     std::set<uint8_t> keys;
     std::set<uint8_t> scan;
     std::set<uint8_t>::iterator scan_iter;
@@ -32,6 +35,7 @@ public:
     void keypress(uint8_t keycode);
     // Gets a clock for LBA4
     bool clock(bool rising); // return true if an interrupt is generated
+    bool busy_scanning() { return !keys.empty(); }
 };
 
 #endif // KEYBOARD_H

--- a/emulator/ncurses-vt100/vt100sim.h
+++ b/emulator/ncurses-vt100/vt100sim.h
@@ -36,6 +36,7 @@ private:
   bool enable_avo;
   long long rt_ticks;
   struct timeval last_sync;
+  int vscan_tick, refresh_clock;
   int scroll_latch;
   int screen_rev;
   int base_attr;


### PR DESCRIPTION
This basically fixes the problem with the cursor flash rate, but also it does the beeps too; even the code `ESC [ 253 q` trick seems to work as it should! (Remember `SET-UP 0` to reset)

From the commit ...

The cursor flash rate depends on the keyboard TX rate so make sure that
it's limited correctly. This means that beep updates will be generated
at the correct rate too; it appears that 48 are sent for a normal beep
so ignore that many repeats. Which gets exact beep recreation.

This showed that the 'alarm' generated timing wasn't sufficiently accurate
so that's been replaced by timing based on the vertical refresh emulation.
(If the CPU is frozen a simple 50ms sleep is used instead.)

With the good clock it is possible to generate a continous rollover
pattern when pasting keypresses to the terminal. Unfortunatly the VT100
ROM appears to be unable to decode this so the virtual keypresses are
NOT overlapped, just directly appended. This does give a significant
improvement in pasting speed.
